### PR TITLE
Fixed the file extension of templates in widgets

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,7 +216,7 @@ function saveRequestResponse(responseJson) {
 			writeFile(filePath +
 				field.name + '^' +
 				result[responseJson.displayValueField].replace(/\./, '') + '^' +
-				result.sys_id + '^' +
+				result.sys_id + '.' +
 				field.fileType,
 				result[field.name], false, function () { });
 		}


### PR DESCRIPTION
previousely widget templates where named '*^html".
Because of that, VS Code could not detect the filetype of templates and no syntax highlighting was available.