### PR TITLE
fix match on resourceFilename/Dirname

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 				"command": "extension.bgScriptExecute",
 				"key": "ctrl+enter",
 				"mac": "cmd+enter",
-				"when": "editorLangId == javascript && resourceFilename =~ /background/"
+				"when": "editorLangId == javascript && resourceDirname =~ /background/"
 			}
 		],
 		"menus": {


### PR DESCRIPTION
Have debugged what is happening and the problem seems to be that `resourceFilename` has only the filename and `resourceDirname` contains the `background` part that you want to match on. Can ensure you that the keyboard shortcut isn't working on my computer without this adjustment (maybe you also have custom shortcuts configured in VSCode?).