### PR TITLE
Prevent saves from triggering sync when outside an instance folder

### DIFF
--- a/src/ExtensionUtils.ts
+++ b/src/ExtensionUtils.ts
@@ -298,6 +298,30 @@ export class ExtensionUtils {
         return nodePath.basename(path)
     }
 
+    hasSettingsFile(filePath: string): boolean {
+        if (!workspace.rootPath) return false;
+        
+        let currentDir = path.dirname(filePath);
+        const rootPath = workspace.rootPath;
+
+        // Traverse up to find _settings.json or settings.json
+        // Limit traversal to stay within workspace root and avoid infinite loops
+        while (currentDir.startsWith(rootPath)) {
+            const settingsPath = path.join(currentDir, "_settings.json");
+            const oldSettingsPath = path.join(currentDir, "settings.json");
+            
+            if (fs.existsSync(settingsPath) || fs.existsSync(oldSettingsPath)) {
+                return true;
+            }
+
+            const parentDir = path.dirname(currentDir);
+            if (parentDir === currentDir) break; // Reached filesystem root
+            currentDir = parentDir;
+        }
+
+        return false;
+    }
+
     joinPaths(...pathParts) : string {
         return nodePath.join(...pathParts);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3165,6 +3165,11 @@ function saveFieldsToServiceNow(documentOrPath: TextDocument | string, fromVsCod
 		return true;
 	}
 
+	// Only sync files that belong to a ServiceNow instance folder (containing _settings.json)
+	if (!eu.hasSettingsFile(filePath)) {
+		return true;
+	}
+
 	let scriptObj = eu.fileNameToObject(documentOrPath);
 
 	if (scriptObj.fieldName == '_test_urls') return true; //helper file, dont save to instance


### PR DESCRIPTION
I ran into an issue where I maintained a separate client SPA in my scriptsync folder but edits to those would trigger the re-sync and make it unable to save the file. This prevents any file outside of an instance folder from triggering the sync.